### PR TITLE
Add Enum DSL Compiler

### DIFF
--- a/lib/boba.rb
+++ b/lib/boba.rb
@@ -4,4 +4,5 @@
 module Boba
   require "boba/version"
   require "boba/relations_railtie" if defined?(Rails)
+  require "boba/enums_railtie" if defined?(Rails)
 end

--- a/lib/boba/enums_railtie.rb
+++ b/lib/boba/enums_railtie.rb
@@ -1,0 +1,95 @@
+# typed: true
+# frozen_string_literal: true
+
+require "rails/railtie"
+
+module Boba
+  class EnumsRailtie < Rails::Railtie
+    railtie_name(:boba)
+
+    initializer("boba.add_enum_classes") do
+      ActiveSupport.on_load(:active_record) do
+        next if defined?(ActiveRecordTypedEnum)
+
+        module ActiveRecordTypedEnum
+          extend T::Sig
+          extend T::Helpers
+
+          module ClassMethods
+            extend T::Sig
+            extend T::Helpers
+            include Kernel
+
+            abstract!
+
+            sig { abstract.returns(T::Hash[String, T::Hash[String, T.untyped]]) }
+            def defined_enums; end
+
+            sig { abstract.params(name: String, value: T.untyped).returns(T.untyped) }
+            def const_set(name, value)
+            end
+
+            sig { abstract.params(name: String, block: T.proc.params(args: T.untyped).void).returns(T.untyped) }
+            def define_method(name, &block)
+            end
+
+            sig { params(args: T.untyped, kwargs: T.untyped).returns(T.untyped) }
+            def enum(*args, **kwargs)
+              # Call the original enum method first
+              result = super
+
+              # Extract definitions based on how enum was called
+              definitions = if args.first.is_a?(Hash)
+                # Rails 6 style: enum(status: {draft: 0, published: 1})
+                args.first
+              elsif args.length >= 2
+                # Rails 7 style: enum(:status, {draft: 0, published: 1})
+                { args[0] => args[1] }
+              elsif kwargs.any?
+                # Keyword style: enum(status: {draft: 0, published: 1})
+                kwargs
+              else
+                {}
+              end
+
+              # Add typed enum methods for each enum
+              definitions.each_key do |name|
+                enum_values = defined_enums.fetch(name.to_s, nil)
+                next if enum_values.nil?
+
+                enum_class = Class.new(T::Enum) do
+                  enums { enum_values.each { |key, _| const_set(key.to_s.camelize, new(key)) } }
+                end
+
+                const_set(name.to_s.camelize, enum_class)
+
+                # Define typed getter method
+                define_method("typed_#{name}") do
+                  value = send(name)
+                  return if value.nil?
+
+                  enum_class.try_deserialize(value)
+                end
+
+                # Define typed setter method
+                define_method("typed_#{name}=") do |typed_value|
+                  send("#{name}=", typed_value&.serialize)
+                end
+              end
+
+              result
+            end
+          end
+
+          mixes_in_class_methods(ClassMethods)
+        end
+
+        module ::ActiveRecord
+          class Base
+            include ActiveRecordTypedEnum
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tapioca/dsl/compilers/active_record_typed_enum.rb
+++ b/lib/tapioca/dsl/compilers/active_record_typed_enum.rb
@@ -1,0 +1,120 @@
+# typed: true
+# frozen_string_literal: true
+
+module Tapioca
+  module Dsl
+    module Compilers
+      # `Tapioca::Dsl::Compilers::ActiveRecordTypedEnum` generates type-safe enum classes and methods
+      # for ActiveRecord models that use the built-in enum feature.
+      #
+      # For each enum defined in a model, this compiler:
+      # 1. Creates a `T::Enum` subclass with all the enum values
+      # 2. Generates `typed_<enum_name>` getter method that returns the enum instance
+      # 3. Generates `typed_<enum_name>=` setter method that accepts the enum instance
+      #
+      # The compiler respects the nullability of the enum attribute based on the database schema.
+      #
+      # For example, with the following ActiveRecord model:
+      #
+      # ~~~rb
+      # class Order < ActiveRecord::Base
+      #   enum status: { pending: 0, processing: 1, completed: 2, cancelled: 3 }
+      #   enum priority: { low: 0, medium: 1, high: 2 }, _prefix: true
+      # end
+      # ~~~
+      #
+      # This compiler will produce the following RBI:
+      #
+      # ~~~rbi
+      # class Order
+      #   class Status < T::Enum
+      #     enums do
+      #       Pending = new(0)
+      #       Processing = new(1)
+      #       Completed = new(2)
+      #       Cancelled = new(3)
+      #     end
+      #   end
+      #
+      #   class Priority < T::Enum
+      #     enums do
+      #       Low = new(0)
+      #       Medium = new(1)
+      #       High = new(2)
+      #     end
+      #   end
+      #
+      #   sig { returns(Order::Status) }
+      #   def typed_status; end
+      #
+      #   sig { params(value: Order::Status).returns(void) }
+      #   def typed_status=(value); end
+      #
+      #   sig { returns(Order::Priority) }
+      #   def typed_priority; end
+      #
+      #   sig { params(value: Order::Priority).returns(void) }
+      #   def typed_priority=(value); end
+      # end
+      # ~~~
+      class ActiveRecordTypedEnum < Tapioca::Dsl::Compiler
+        extend T::Sig
+
+        ConstantType = type_member { { fixed: T.class_of(ActiveRecord::Base) } }
+
+        class << self
+          extend T::Sig
+
+          sig { override.returns(T::Enumerable[Module]) }
+          def gather_constants
+            ActiveRecord::Base.descendants.select do |klass|
+              klass.respond_to?(:defined_enums) && klass.defined_enums.any? && klass.table_exists?
+            end
+          end
+        end
+
+        sig { override.void }
+        def decorate
+          return unless constant.respond_to?(:defined_enums)
+
+          constant.defined_enums.each do |enum_name, enum_values|
+            # Create the enum class
+            enum_class_name = enum_name.camelize
+
+            root.create_path(constant) do |model|
+              # Create the T::Enum using RBI::TEnum
+              enum_class =
+                RBI::TEnum.new(enum_class_name) do |tenum|
+                  # Try to create a TEnumBlock for the enums do block
+                  enum_block =
+                    RBI::TEnumBlock.new do |block|
+                      enum_values.each do |key, _|
+                        block.create_constant(key.to_s.camelize, value: "new('#{key}')")
+                      end
+                    end
+
+                  tenum << enum_block
+                end
+
+              model << enum_class
+
+              nullability = Boba::ActiveRecord::AttributeService.nilable_attribute?(constant, enum_name)
+              base_enum_type = "#{constant}::#{enum_class_name}"
+              enum_type = nullability ? "T.nilable(#{base_enum_type})" : base_enum_type
+
+              # Generate typed getter
+              model.create_method("typed_#{enum_name}", return_type: enum_type)
+
+              # Generate typed setter
+              model.create_method(
+                "typed_#{enum_name}=",
+                parameters: [create_param("value", type: enum_type)],
+                return_type: "void",
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/manual/compiler_activerecordtypedenum.md
+++ b/manual/compiler_activerecordtypedenum.md
@@ -1,0 +1,55 @@
+## ActiveRecordTypedEnum
+
+`Tapioca::Dsl::Compilers::ActiveRecordTypedEnum` generates type-safe enum classes and methods
+for ActiveRecord models that use the built-in enum feature.
+
+For each enum defined in a model, this compiler:
+1. Creates a `T::Enum` subclass with all the enum values
+2. Generates `typed_<enum_name>` getter method that returns the enum instance
+3. Generates `typed_<enum_name>=` setter method that accepts the enum instance
+
+The compiler respects the nullability of the enum attribute based on the database schema.
+
+For example, with the following ActiveRecord model:
+
+~~~rb
+class Order < ActiveRecord::Base
+  enum status: { pending: 0, processing: 1, completed: 2, cancelled: 3 }
+  enum priority: { low: 0, medium: 1, high: 2 }, _prefix: true
+end
+~~~
+
+This compiler will produce the following RBI:
+
+~~~rbi
+class Order
+  class Status < T::Enum
+    enums do
+      Pending = new(0)
+      Processing = new(1)
+      Completed = new(2)
+      Cancelled = new(3)
+    end
+  end
+
+  class Priority < T::Enum
+    enums do
+      Low = new(0)
+      Medium = new(1)
+      High = new(2)
+    end
+  end
+
+  sig { returns(Order::Status) }
+  def typed_status; end
+
+  sig { params(value: Order::Status).returns(void) }
+  def typed_status=(value); end
+
+  sig { returns(Order::Priority) }
+  def typed_priority; end
+
+  sig { params(value: Order::Priority).returns(void) }
+  def typed_priority=(value); end
+end
+~~~

--- a/manual/compilers.md
+++ b/manual/compilers.md
@@ -7,6 +7,7 @@ This list is an evergeen list of currently available compilers.
 <!-- START_COMPILER_LIST -->
 * [ActiveRecordAssociationsPersisted](compiler_activerecordassociationspersisted.md)
 * [ActiveRecordColumnsPersisted](compiler_activerecordcolumnspersisted.md)
+* [ActiveRecordTypedEnum](compiler_activerecordtypedenum.md)
 * [AttrJson](compiler_attrjson.md)
 * [FlagShihTzu](compiler_flagshihtzu.md)
 * [Kaminari](compiler_kaminari.md)

--- a/spec/tapioca/dsl/compilers/active_record_typed_enum_spec.rb
+++ b/spec/tapioca/dsl/compilers/active_record_typed_enum_spec.rb
@@ -1,0 +1,318 @@
+# typed: strict
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "active_record"
+require "rails"
+
+module Tapioca
+  module Dsl
+    module Compilers
+      class ActiveRecordTypedEnumSpec < ::DslSpec
+        before do
+          ::ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+        end
+
+        after do
+          ::ActiveRecord::Base.connection.disconnect!
+        end
+
+        describe "Tapioca::Dsl::Compilers::ActiveRecordTypedEnum" do
+          describe "initialize" do
+            it "gathers no constants if there are no ActiveRecord classes with enums" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :posts do |t|
+                      t.string :title
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                end
+              RUBY
+
+              assert_equal(gathered_constants, [])
+            end
+
+            it "gathers ActiveRecord classes with enums" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :posts do |t|
+                      t.integer :status, default: 0
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  enum :status, [:draft, :published, :archived]
+                end
+              RUBY
+
+              assert_equal(gathered_constants, ["Post"])
+            end
+          end
+
+          describe "decorate" do
+            it "generates typed enum class and typed getter/setter methods" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :posts do |t|
+                      t.integer :status, default: 0
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  enum :status, [:draft, :published, :archived]
+                end
+              RUBY
+
+              expected = template(<<~RBI, trim_mode: "-")
+                # typed: strong
+
+                class Post
+                  sig { returns(T.nilable(Post::Status)) }
+                  def typed_status; end
+
+                  sig { params(value: T.nilable(Post::Status)).void }
+                  def typed_status=(value); end
+
+                  class Status < T::Enum
+                    enums do
+                      Archived = new('archived')
+                      Draft = new('draft')
+                      Published = new('published')
+                    end
+                  end
+                end
+              RBI
+              assert_equal(expected, rbi_for(:Post))
+            end
+
+            it "generates typed enum with hash values" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :posts do |t|
+                      t.integer :status, default: 0
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  enum :status, { draft: 0, published: 1, archived: 2 }
+                end
+              RUBY
+
+              expected = template(<<~RBI, trim_mode: "-")
+                # typed: strong
+
+                class Post
+                  sig { returns(T.nilable(Post::Status)) }
+                  def typed_status; end
+
+                  sig { params(value: T.nilable(Post::Status)).void }
+                  def typed_status=(value); end
+
+                  class Status < T::Enum
+                    enums do
+                      Archived = new('archived')
+                      Draft = new('draft')
+                      Published = new('published')
+                    end
+                  end
+                end
+              RBI
+              assert_equal(expected, rbi_for(:Post))
+            end
+
+            it "generates typed enum with string values" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :posts do |t|
+                      t.integer :status, default: 0
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  enum :status, { draft: "draft", published: "published", archived: "archived" }
+                end
+              RUBY
+
+              expected = template(<<~RBI, trim_mode: "-")
+                # typed: strong
+
+                class Post
+                  sig { returns(T.nilable(Post::Status)) }
+                  def typed_status; end
+
+                  sig { params(value: T.nilable(Post::Status)).void }
+                  def typed_status=(value); end
+
+                  class Status < T::Enum
+                    enums do
+                      Archived = new('archived')
+                      Draft = new('draft')
+                      Published = new('published')
+                    end
+                  end
+                end
+              RBI
+              assert_equal(expected, rbi_for(:Post))
+            end
+
+            it "generates non-nilable types for non-nullable columns" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :posts do |t|
+                      t.integer :status, null: false
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  enum :status, [:draft, :published, :archived]
+                end
+              RUBY
+
+              expected = template(<<~RBI, trim_mode: "-")
+                # typed: strong
+
+                class Post
+                  sig { returns(Post::Status) }
+                  def typed_status; end
+
+                  sig { params(value: Post::Status).void }
+                  def typed_status=(value); end
+
+                  class Status < T::Enum
+                    enums do
+                      Archived = new('archived')
+                      Draft = new('draft')
+                      Published = new('published')
+                    end
+                  end
+                end
+              RBI
+              assert_equal(expected, rbi_for(:Post))
+            end
+
+            it "generates multiple enum classes for multiple enums" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :posts do |t|
+                      t.integer :status, default: 0
+                      t.integer :visibility, default: 0
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  enum :status, [:draft, :published, :archived]
+                  enum :visibility, [:shared, :personal, :unlisted]
+                end
+              RUBY
+
+              expected = template(<<~RBI, trim_mode: "-")
+                # typed: strong
+
+                class Post
+                  sig { returns(T.nilable(Post::Status)) }
+                  def typed_status; end
+
+                  sig { params(value: T.nilable(Post::Status)).void }
+                  def typed_status=(value); end
+
+                  sig { returns(T.nilable(Post::Visibility)) }
+                  def typed_visibility; end
+
+                  sig { params(value: T.nilable(Post::Visibility)).void }
+                  def typed_visibility=(value); end
+
+                  class Status < T::Enum
+                    enums do
+                      Archived = new('archived')
+                      Draft = new('draft')
+                      Published = new('published')
+                    end
+                  end
+
+                  class Visibility < T::Enum
+                    enums do
+                      Personal = new('personal')
+                      Shared = new('shared')
+                      Unlisted = new('unlisted')
+                    end
+                  end
+                end
+              RBI
+              assert_equal(expected, rbi_for(:Post))
+            end
+
+            it "handles enum keys with underscores" do
+              add_ruby_file("schema.rb", <<~RUBY)
+                ActiveRecord::Migration.suppress_messages do
+                  ActiveRecord::Schema.define do
+                    create_table :posts do |t|
+                      t.integer :review_status, default: 0
+                    end
+                  end
+                end
+              RUBY
+
+              add_ruby_file("post.rb", <<~RUBY)
+                class Post < ActiveRecord::Base
+                  enum :review_status, [:pending_review, :under_review, :review_completed]
+                end
+              RUBY
+
+              expected = template(<<~RBI, trim_mode: "-")
+                # typed: strong
+
+                class Post
+                  sig { returns(T.nilable(Post::ReviewStatus)) }
+                  def typed_review_status; end
+
+                  sig { params(value: T.nilable(Post::ReviewStatus)).void }
+                  def typed_review_status=(value); end
+
+                  class ReviewStatus < T::Enum
+                    enums do
+                      PendingReview = new('pending_review')
+                      ReviewCompleted = new('review_completed')
+                      UnderReview = new('under_review')
+                    end
+                  end
+                end
+              RBI
+              assert_equal(expected, rbi_for(:Post))
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds both a DSL Compiler and a Railstie Engine that work together to replace the `T::Enum` functionality from `sorbet-rails`. The sorbet-rails functionality is documented here: https://github.com/chanzuckerberg/sorbet-rails#typed_enum-instead-of-enum

Essentially it transforms Rails `enum` calls into `T::Enum` classes so we can use Sorbet Type Checking on the enums for exhaustive checks!

This PR is pointed to `main` on our fork. We WILL also try to upstream those changes, but I don't want to hold that on getting our usage adjusted!