### PR TITLE
update allowed tapioca version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     boba (0.1.2)
       sorbet-static-and-runtime (~> 0.5)
-      tapioca (<= 0.17.2)
+      tapioca (~> 0.17)
 
 GEM
   remote: https://rubygems.org/

--- a/boba.gemspec
+++ b/boba.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 3.0.0"
 
   spec.add_dependency("sorbet-static-and-runtime", "~> 0.5")
-  spec.add_dependency("tapioca", "<= 0.17.2")
+  spec.add_dependency("tapioca", "~> 0.17")
 end


### PR DESCRIPTION
part of: https://linear.app/wellsheet/issue/ENG-537/upgrade-to-rails-72 

During upgrading rails to 7.0.8.7, zeitwerk wanted to upgrade from 2.7.2 to 2.7.3, However, this broke the tapioca script with the error

tapioca-0.16.11/lib/tapioca/loaders/loader.rb:116:in `load_engines_in_zeitwerk_mode': undefined method `flat_map' for an instance of Zeitwerk::Registry::Loaders (NoMethodError). managed_dirs = Zeitwerk::Registry.loaders.flat_map(&:dirs).to_set

We've temporarily gone around this error by leaving zeitwerk to version 2.7.2 but we really should be able to allow for patch upgrades.

To upgrade tapioca we'll have to allow for our boba fork use a higher version. 